### PR TITLE
refactor index: no need to put require in try catch and then throw, it will throw anyways

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -30,8 +30,4 @@ fs.writeFileSync(bin, code, "utf-8");
   );
 })();
 
-try {
-  require(bin);
-} catch (e) {
-  throw new Error(e);
-};
+require(bin);


### PR DESCRIPTION
Removed redundant `try-catch` block.